### PR TITLE
Add Slack fixture fetcher workflow

### DIFF
--- a/.github/workflows/slack-fixture-fetcher.yml
+++ b/.github/workflows/slack-fixture-fetcher.yml
@@ -1,0 +1,169 @@
+name: Slack Fixture Fetcher
+
+on:
+  workflow_dispatch:
+    inputs:
+      lookback_hours:
+        description: "How many hours of Slack history to fetch"
+        required: false
+        default: "24"
+      channel_ids:
+        description: "Optional comma-separated Slack channel IDs. Defaults to SLACK_ALLOWED_CHANNEL_IDS."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: slack-fixture-fetcher
+  cancel-in-progress: false
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_ALLOWED_CHANNEL_IDS: ${{ vars.SLACK_ALLOWED_CHANNEL_IDS }}
+      INPUT_CHANNEL_IDS: ${{ inputs.channel_ids }}
+      LOOKBACK_HOURS: ${{ inputs.lookback_hours }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Fetch Slack fixture
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+          const path = require("path");
+
+          const token = process.env.SLACK_BOT_TOKEN;
+          const configuredAllowed = (process.env.SLACK_ALLOWED_CHANNEL_IDS || "")
+            .split(",")
+            .map((value) => value.trim())
+            .filter(Boolean);
+          const requested = (process.env.INPUT_CHANNEL_IDS || "")
+            .split(",")
+            .map((value) => value.trim())
+            .filter(Boolean);
+          const allowed = new Set(configuredAllowed);
+          const channelIds = requested.length ? requested : configuredAllowed;
+          const lookbackHours = Number(process.env.LOOKBACK_HOURS || "24");
+
+          if (!token) {
+            throw new Error("SLACK_BOT_TOKEN is not configured.");
+          }
+
+          if (!configuredAllowed.length) {
+            throw new Error("SLACK_ALLOWED_CHANNEL_IDS must contain at least one channel ID.");
+          }
+
+          if (!Number.isFinite(lookbackHours) || lookbackHours <= 0 || lookbackHours > 168) {
+            throw new Error("lookback_hours must be between 1 and 168.");
+          }
+
+          for (const channelId of channelIds) {
+            if (!allowed.has(channelId)) {
+              throw new Error(`Requested channel is not allowlisted: ${channelId}`);
+            }
+          }
+
+          async function slack(method, params) {
+            const response = await fetch(`https://slack.com/api/${method}`, {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${token}`,
+                "Content-Type": "application/json; charset=utf-8"
+              },
+              body: JSON.stringify(params)
+            });
+            const json = await response.json();
+            if (!response.ok || !json.ok) {
+              throw new Error(`${method} failed: ${json.error || response.statusText}`);
+            }
+            return json;
+          }
+
+          function isoFromTs(ts) {
+            const [seconds, micros = "0"] = String(ts).split(".");
+            const millis = Number(seconds) * 1000 + Math.floor(Number(micros.padEnd(6, "0")) / 1000);
+            return new Date(millis).toISOString();
+          }
+
+          const oldest = Math.floor(Date.now() / 1000 - lookbackHours * 60 * 60).toString();
+          const fixture = {
+            fetched_at: new Date().toISOString(),
+            lookback_hours: lookbackHours,
+            channels: [],
+            messages: [],
+            events: []
+          };
+
+          for (const channelId of channelIds) {
+            const channelName = channelId;
+
+            fixture.channels.push({ channel_id: channelId, channel_name: channelName });
+
+            let cursor;
+            do {
+              const history = await slack("conversations.history", {
+                channel: channelId,
+                oldest,
+                limit: 100,
+                cursor
+              });
+
+              for (const message of history.messages || []) {
+                if (!message.text || message.subtype) {
+                  continue;
+                }
+
+                const permalink = await slack("chat.getPermalink", {
+                  channel: channelId,
+                  message_ts: message.ts
+                });
+
+                fixture.messages.push({
+                  channel_id: channelId,
+                  channel_name: channelName,
+                  thread_ts: message.thread_ts || message.ts,
+                  message_ts: message.ts,
+                  permalink: permalink.permalink,
+                  author_id: message.user || message.bot_id || "unknown",
+                  author_name: message.username || message.user || message.bot_id || "unknown",
+                  created_at: isoFromTs(message.ts),
+                  text: message.text,
+                  reactions: (message.reactions || []).map((reaction) => reaction.name),
+                  matched_by: []
+                });
+              }
+
+              cursor = history.response_metadata?.next_cursor || "";
+            } while (cursor);
+          }
+
+          const date = new Date().toISOString().slice(0, 10);
+          const dir = path.join("slack-fixtures");
+          fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync(
+            path.join(dir, `slack-${date}.json`),
+            JSON.stringify(fixture, null, 2) + "\n"
+          );
+          NODE
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Add Slack fixture"
+          title: "Add Slack fixture"
+          body: |
+            Adds a Slack fixture fetched from the allowlisted demo channel.
+
+            Once merged, the Slack Context Processor workflow can match the
+            fixture against open GitHub issues and post context comments.
+          branch: sample-data/slack-fixture
+          delete-branch: true
+          labels: ai:slack-fixture
+          add-paths: |
+            slack-fixtures/*.json

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -154,6 +154,11 @@ Slack channel IDs:
 gh variable set SLACK_ALLOWED_CHANNEL_IDS --body "C0123456789,C9876543210"
 ```
 
+If enabling the Slack Fixture Fetcher workflow, also set `SLACK_BOT_TOKEN` as a
+repository secret. The first read-only demo requires `channels:history` and
+`reactions:read` on the Slack app, plus `groups:history` if the allowlisted
+channel is private.
+
 ### 4. Create an Intake Triage project
 
 Create a second GitHub Project (Projects V2) to track incoming feature requests and bug reports. Add these custom fields:

--- a/docs/slack-integration-plan.md
+++ b/docs/slack-integration-plan.md
@@ -510,6 +510,9 @@ Suggested secrets:
 - Add a deterministic Slack fetch script or Slack MCP configuration.
 - For the MVP, read synthetic `slack-fixtures/*.json` files before adding real
   Slack API access.
+- Use `.github/workflows/slack-fixture-fetcher.yml` to manually fetch recent
+  messages from allowlisted Slack channels into a `slack-fixtures/*.json` pull
+  request.
 - When real Slack access is added, fetch messages only from allowlisted
   channels.
 - Match on GitHub issue URLs, issue numbers, and exact artifact titles.


### PR DESCRIPTION
## Summary
- adds a manual Slack Fixture Fetcher GitHub Actions workflow
- fetches recent messages from allowlisted Slack channels using SLACK_BOT_TOKEN
- writes Slack-shaped JSON to slack-fixtures/ and opens a PR for the fixture
- documents the Slack secret/scope requirements and fixture-first rollout

## Validation
- ruby YAML parse for .github/workflows/slack-fixture-fetcher.yml
- git diff --check

## Security review note
This workflow introduces use of SLACK_BOT_TOKEN in a regular GitHub Actions workflow. The token is used only in the deterministic fetch job, not exposed to an agent. Fetching is constrained to channel IDs listed in SLACK_ALLOWED_CHANNEL_IDS, optional workflow_dispatch channel input is checked against that allowlist, and lookback_hours is capped at 168. The workflow writes only slack-fixtures/*.json through a pull request.