### PR TITLE
Fix Slack explicit issue matching

### DIFF
--- a/.github/workflows/slack-context-processor.lock.yml
+++ b/.github/workflows/slack-context-processor.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"35f2d037da541ac8f6502f146674204e0c08e69434836941757ac441d533d51c","body_hash":"cf1154f7b06b6c34d64a68d03c3acb68fab391811121854fa9862114be82d855","compiler_version":"v0.77.4","strict":true,"agent_id":"codex","agent_model":"gpt-5-mini"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"35f2d037da541ac8f6502f146674204e0c08e69434836941757ac441d533d51c","body_hash":"04086e5ef506f30f3f54cccb7d7b5583437214e5bcc0d59f9ecb2da86dc898a2","compiler_version":"v0.77.4","strict":true,"agent_id":"codex","agent_model":"gpt-5-mini"}
 # gh-aw-manifest: {"version":1,"secrets":["AW_TOKEN","CODEX_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","OPENAI_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"4c7307f890279fa5971acae8899475901fea9447","version":"v0.77.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -1289,18 +1289,18 @@ jobs:
           DOCKER_SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK_PATH" 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.22'
           
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_f4f7957db5fc30d6_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_cbacf52daba1013e_EOF
           [history]
           persistence = "none"
           
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_MCP_CONFIG_f4f7957db5fc30d6_EOF
+          GH_AW_MCP_CONFIG_cbacf52daba1013e_EOF
           
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_261a325fa2124496_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_55d2d15715f4b960_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
             },
@@ -1311,11 +1311,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_261a325fa2124496_EOF
+          GH_AW_MCP_CONFIG_55d2d15715f4b960_EOF
           
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_bbc0032d8dcd8d7b_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_75bff2eaef96e0e9_EOF
           model_provider = "openai-proxy"
           [model_providers.openai-proxy]
           name = "OpenAI AWF proxy"
@@ -1325,7 +1325,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_CODEX_SHELL_POLICY_bbc0032d8dcd8d7b_EOF
+          GH_AW_CODEX_SHELL_POLICY_75bff2eaef96e0e9_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }

--- a/.github/workflows/slack-context-processor.md
+++ b/.github/workflows/slack-context-processor.md
@@ -151,7 +151,8 @@ jq '[.launches[] | select(.state == "OPEN") | {number, title, url, state, type: 
   (.subIssues[]?.subIssues[]? | select(.state == "OPEN") | {number, title, url, state, type: "task"})]' launch-data-summary.json
 ```
 
-Also detect issue references inside Slack text and permalinks:
+Then detect explicit issue references inside Slack text and permalinks before
+doing title or keyword matching:
 
 - `#123`
 - `issue 123`
@@ -160,13 +161,28 @@ Also detect issue references inside Slack text and permalinks:
   `https://github.com/${{ github.repository }}/issues/123`
 - exact or near-exact issue titles
 
+Explicit same-repository issue references are authoritative. If a Slack message
+contains `https://github.com/${{ github.repository }}/issues/123`, `#123`,
+`issue 123`, or `ticket 123`, verify the issue directly even when it is absent
+from `launch-data-summary.json`:
+
+```bash
+gh issue view <number> --repo ${{ github.repository }} \
+  --json number,title,state,url,labels
+```
+
+Only post for verified open issues. Skip closed issues. Use the launch data as
+context and as the source for title/keyword matching, but do not use it as a
+gate that can exclude an explicit same-repository issue reference.
+
 ### Step 4: Match Slack Messages to Issues
 
 For each Slack message or thread, determine whether it relates to an open issue.
 
 Matching confidence:
 
-- **High:** Explicit GitHub issue URL, `#123`, `issue 123`, or exact title.
+- **High:** Verified explicit same-repository GitHub issue URL, `#123`,
+  `issue 123`, `ticket 123`, or exact title.
 - **Medium:** Strong title/keyword overlap plus a relevant reaction such as
   `memo`, `pushpin`, `warning`, or `white_check_mark`.
 - **Low:** Loose keyword overlap, generic project terms, or unclear references.


### PR DESCRIPTION
## Summary
- Treat explicit same-repository Slack issue references as authoritative matches.
- Verify referenced issues directly with gh issue view before commenting.
- Recompile the Slack Context Processor lock file.

## Validation
- gh aw compile slack-context-processor --approve
- gh aw validate slack-context-processor