### PR TITLE
Use friendly Slack author fallbacks

### DIFF
--- a/.github/workflows/slack-context-processor.lock.yml
+++ b/.github/workflows/slack-context-processor.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"35f2d037da541ac8f6502f146674204e0c08e69434836941757ac441d533d51c","body_hash":"4f2fb19f91df8e137e958b4bebf868a06e94aed8da9f408860e0261464645892","compiler_version":"v0.77.4","strict":true,"agent_id":"codex","agent_model":"gpt-5-mini"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"35f2d037da541ac8f6502f146674204e0c08e69434836941757ac441d533d51c","body_hash":"48a0036c45b0959eea019cd7c6a5a4a687f4e2efd443c40baf47b2278ec90124","compiler_version":"v0.77.4","strict":true,"agent_id":"codex","agent_model":"gpt-5-mini"}
 # gh-aw-manifest: {"version":1,"secrets":["AW_TOKEN","CODEX_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","OPENAI_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"4c7307f890279fa5971acae8899475901fea9447","version":"v0.77.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -1289,18 +1289,18 @@ jobs:
           DOCKER_SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK_PATH" 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.22'
           
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_0e338a5f7d1ee63c_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_3625003dcf0b0903_EOF
           [history]
           persistence = "none"
           
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_MCP_CONFIG_0e338a5f7d1ee63c_EOF
+          GH_AW_MCP_CONFIG_3625003dcf0b0903_EOF
           
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_025187a0362bc8dc_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_d997b435fcb4bb73_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
             },
@@ -1311,11 +1311,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_025187a0362bc8dc_EOF
+          GH_AW_MCP_CONFIG_d997b435fcb4bb73_EOF
           
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_eb264a9b5fbae225_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_eecea9334aba20c5_EOF
           model_provider = "openai-proxy"
           [model_providers.openai-proxy]
           name = "OpenAI AWF proxy"
@@ -1325,7 +1325,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_CODEX_SHELL_POLICY_eb264a9b5fbae225_EOF
+          GH_AW_CODEX_SHELL_POLICY_eecea9334aba20c5_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }

--- a/.github/workflows/slack-context-processor.md
+++ b/.github/workflows/slack-context-processor.md
@@ -256,8 +256,8 @@ Use this default format for general context:
 <details>
 <summary>Copied Slack context</summary>
 
-- <author_name>: "<short copied message excerpt>"
-- <author_name>: "<short copied message excerpt>"
+- <readable author>: "<short copied message excerpt>"
+- <readable author>: "<short copied message excerpt>"
 
 </details>
 ```
@@ -295,12 +295,18 @@ questions:
 <details>
 <summary>Copied Slack context</summary>
 
-- <author_name>: "<short copied message excerpt>"
+- <readable author>: "<short copied message excerpt>"
 
 </details>
 ```
 
 Omit empty sections in the Decision/Action-Oriented format.
+
+For copied Slack context author labels, prefer `author_name` only when it is a
+human-readable display name. If `author_name` is missing, `unknown`, or looks
+like a Slack ID such as `U123...`, `W123...`, or `B123...`, use a neutral label
+such as `Slack participant` or `Slack app`. Do not expose raw Slack user IDs in
+GitHub comments.
 
 For evidence links, use the raw `permalink` value from the fixture exactly when
 it starts with `http://` or `https://`. If the permalink is missing or has been

--- a/.github/workflows/slack-fixture-fetcher.yml
+++ b/.github/workflows/slack-fixture-fetcher.yml
@@ -96,6 +96,16 @@ jobs:
               return `https://slack.com/archives/${channelId}/p${String(ts).replace(".", "")}`;
             }
 
+            function authorNameFor(message) {
+              if (message.username && !/^[UW][A-Z0-9]+$/.test(message.username)) {
+                return message.username;
+              }
+              if (message.bot_id) {
+                return "Slack app";
+              }
+              return "Slack participant";
+            }
+
             const oldest = Math.floor(Date.now() / 1000 - lookbackHours * 60 * 60).toString();
             const fixture = {
               fetched_at: new Date().toISOString(),
@@ -131,7 +141,7 @@ jobs:
                     message_ts: message.ts,
                     permalink: permalinkFor(channelId, message.ts),
                     author_id: message.user || message.bot_id || "unknown",
-                    author_name: message.username || message.user || message.bot_id || "unknown",
+                    author_name: authorNameFor(message),
                     created_at: isoFromTs(message.ts),
                     text: message.text,
                     reactions: (message.reactions || []).map((reaction) => reaction.name),


### PR DESCRIPTION
## Summary
- Avoid storing raw Slack user IDs as author names in fetched fixtures.
- Tell Slack Context Processor to render ID-like author names as neutral labels such as Slack participant.
- Recompile Slack Context Processor.
- Updated the existing #172 Slack comment to remove the raw user ID and malformed redacted link.

## Validation
- ruby YAML parse for slack-fixture-fetcher.yml
- gh aw compile slack-context-processor --approve
- gh aw validate slack-context-processor