### PR TITLE
Make Slack reaction intake deterministic

### DIFF
--- a/.github/scripts/slack-reaction-intake-candidates.mjs
+++ b/.github/scripts/slack-reaction-intake-candidates.mjs
@@ -1,0 +1,158 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+function listFixtureFiles() {
+  if (process.env.GITHUB_EVENT_NAME === "push") {
+    try {
+      const output = execFileSync("git", ["diff", "--name-only", "HEAD~1", "HEAD"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      return output
+        .split(/\r?\n/)
+        .filter((file) => /^slack-fixtures\/.*\.json$/.test(file));
+    } catch {
+      return [];
+    }
+  }
+
+  const root = "slack-fixtures";
+  if (!fs.existsSync(root)) {
+    return [];
+  }
+
+  const files = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith(".json")) {
+        files.push(fullPath);
+      }
+    }
+  };
+  walk(root);
+  return files.sort();
+}
+
+function textFrom(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isReadableAuthor(value) {
+  return value && !/^[UWB][A-Z0-9]+$/.test(value) && value.toLowerCase() !== "unknown";
+}
+
+function authorName(message) {
+  const name = textFrom(message.author_name || message.username || message.user_name);
+  if (isReadableAuthor(name)) {
+    return name;
+  }
+  if (message.bot_id) {
+    return "Slack app";
+  }
+  return "Slack participant";
+}
+
+function validPermalink(value) {
+  const link = textFrom(value);
+  return /^https?:\/\//.test(link) ? link : "";
+}
+
+function collectMessages(value, messages = []) {
+  if (!value || typeof value !== "object") {
+    return messages;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectMessages(item, messages);
+    }
+    return messages;
+  }
+
+  if (textFrom(value.text) && (value.message_ts || value.ts)) {
+    messages.push(value);
+  }
+
+  for (const nested of Object.values(value)) {
+    if (nested && typeof nested === "object") {
+      collectMessages(nested, messages);
+    }
+  }
+
+  return messages;
+}
+
+function hasInboxTray(message) {
+  const reactions = Array.isArray(message.reactions) ? message.reactions : [];
+  return reactions.some((reaction) => {
+    if (typeof reaction === "string") {
+      return reaction === "inbox_tray";
+    }
+    return reaction && reaction.name === "inbox_tray";
+  });
+}
+
+function summarizeTitle(text) {
+  const cleaned = text.replace(/\s+/g, " ").trim();
+  const issueFor = cleaned.match(/^(?:please\s+)?can we\s+open\s+an?\s+issue\s+for\s+(.+?)(?:\?|\.|$)/i);
+  if (issueFor?.[1]) {
+    const subject = issueFor[1].replace(/^(the|a|an)\s+/i, "").trim();
+    const titled = `${subject.charAt(0).toUpperCase()}${subject.slice(1)} follow-up`;
+    return titled.length > 90 ? `${titled.slice(0, 87).trim()}...` : titled;
+  }
+  const withoutLead = cleaned.replace(/^(please\s+)?(can we\s+)?(open|create|track)\s+(an?\s+)?(issue|ticket)\s+(for|to)?\s*/i, "");
+  const title = withoutLead || cleaned || "Slack reaction intake request";
+  return title.length > 90 ? `${title.slice(0, 87).trim()}...` : title;
+}
+
+const files = listFixtureFiles();
+const seen = new Set();
+const candidates = [];
+
+for (const fixture of files) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(fixture, "utf8"));
+  } catch {
+    continue;
+  }
+
+  for (const message of collectMessages(parsed)) {
+    if (!hasInboxTray(message)) {
+      continue;
+    }
+
+    const channelId = textFrom(message.channel_id || message.channel);
+    const messageTs = textFrom(message.message_ts || message.ts);
+    const text = textFrom(message.text);
+    if (!channelId || !messageTs || !text) {
+      continue;
+    }
+
+    const idempotencyKey = `slack-reaction-intake:${channelId}:${messageTs}:inbox_tray`;
+    if (seen.has(idempotencyKey)) {
+      continue;
+    }
+    seen.add(idempotencyKey);
+
+    candidates.push({
+      idempotency_key: idempotencyKey,
+      title: summarizeTitle(text),
+      summary: text,
+      copied_context: text.length > 500 ? `${text.slice(0, 497).trim()}...` : text,
+      author_name: authorName(message),
+      channel_id: channelId,
+      channel_name: textFrom(message.channel_name || channelId),
+      message_ts: messageTs,
+      thread_ts: textFrom(message.thread_ts || messageTs),
+      permalink: validPermalink(message.permalink),
+      fixture,
+    });
+  }
+}
+
+console.log(JSON.stringify({ fixture_files: files, candidates }, null, 2));

--- a/.github/workflows/slack-reaction-intake.lock.yml
+++ b/.github/workflows/slack-reaction-intake.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"7ef720fcc2ce3b6a96c1da214d4fca570f05f615a31dedc153a1d61fb39bffa9","body_hash":"45c099b3872c84bd479b6f10974a1638bdd6ddface42d263b70604d6de58afbd","compiler_version":"v0.77.4","strict":true,"agent_id":"codex","agent_model":"gpt-5-mini"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"aa571519177ab00f231888c256d14019ebcf8e7c6889e4ed47e7a4de141e1ccd","body_hash":"e8336dffbc0877dcf4220e6ed6b0c9b2ffed865d93e9879fa27e697d4b485abb","compiler_version":"v0.77.4","strict":true,"agent_id":"codex","agent_model":"gpt-5-mini"}
 # gh-aw-manifest: {"version":1,"secrets":["CODEX_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","OPENAI_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"4c7307f890279fa5971acae8899475901fea9447","version":"v0.77.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -199,20 +199,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_7193fedcf8c2215f_EOF'
+          cat << 'GH_AW_PROMPT_646b978be851a1eb_EOF'
           <system>
-          GH_AW_PROMPT_7193fedcf8c2215f_EOF
+          GH_AW_PROMPT_646b978be851a1eb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7193fedcf8c2215f_EOF'
+          cat << 'GH_AW_PROMPT_646b978be851a1eb_EOF'
           <safe-output-tools>
-          Tools: create_issue(max:10), add_labels(max:20), missing_tool, missing_data, noop
+          Tools: create_issue(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_7193fedcf8c2215f_EOF
+          GH_AW_PROMPT_646b978be851a1eb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_7193fedcf8c2215f_EOF'
+          cat << 'GH_AW_PROMPT_646b978be851a1eb_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -241,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_7193fedcf8c2215f_EOF
+          GH_AW_PROMPT_646b978be851a1eb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7193fedcf8c2215f_EOF'
+          cat << 'GH_AW_PROMPT_646b978be851a1eb_EOF'
           </system>
           {{#runtime-import .github/workflows/slack-reaction-intake.md}}
-          GH_AW_PROMPT_7193fedcf8c2215f_EOF
+          GH_AW_PROMPT_646b978be851a1eb_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -454,41 +454,21 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_93b523cb5b311195_EOF'
-          {"add_labels":{"allowed":["triage-needed","from-slack"],"max":20},"create_issue":{"max":10,"title_prefix":"[Slack Intake] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_93b523cb5b311195_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8af9d7d47b718a89_EOF'
+          {"create_issue":{"labels":["from-slack","triage-needed"],"max":10,"title_prefix":"[Slack Intake] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_8af9d7d47b718a89_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_labels": " CONSTRAINTS: Maximum 20 label(s) can be added. Only these labels are allowed: [\"triage-needed\" \"from-slack\"].",
-                "create_issue": " CONSTRAINTS: Maximum 10 issue(s) can be created. Title will be prefixed with \"[Slack Intake] \"."
+                "create_issue": " CONSTRAINTS: Maximum 10 issue(s) can be created. Title will be prefixed with \"[Slack Intake] \". Labels [\"from-slack\" \"triage-needed\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
             }
           GH_AW_VALIDATION_JSON: |
             {
-              "add_labels": {
-                "defaultMax": 5,
-                "fields": {
-                  "item_number": {
-                    "issueNumberOrTemporaryId": true
-                  },
-                  "labels": {
-                    "required": true,
-                    "type": "array",
-                    "itemType": "string",
-                    "itemSanitize": true,
-                    "itemMaxLength": 128
-                  },
-                  "repo": {
-                    "type": "string",
-                    "maxLength": 256
-                  }
-                }
-              },
               "create_issue": {
                 "defaultMax": 1,
                 "fields": {
@@ -680,7 +660,7 @@ jobs:
           DOCKER_SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK_PATH" 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.22'
           
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_549a33ea2ad22d10_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_e9c3334eb252a763_EOF
           [history]
           persistence = "none"
           
@@ -699,11 +679,11 @@ jobs:
           
           [mcp_servers.safeoutputs."guard-policies".write-sink]
           accept = ["*"]
-          GH_AW_MCP_CONFIG_549a33ea2ad22d10_EOF
+          GH_AW_MCP_CONFIG_e9c3334eb252a763_EOF
           
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_549a33ea2ad22d10_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e9c3334eb252a763_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -728,11 +708,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_549a33ea2ad22d10_EOF
+          GH_AW_MCP_CONFIG_e9c3334eb252a763_EOF
           
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_82f6585bd0d42c57_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_44e78737e3f8461e_EOF
 
           model_provider = "openai-proxy"
 
@@ -744,7 +724,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^GH_AW_ASSETS_ALLOWED_EXTS$", "^GH_AW_ASSETS_BRANCH$", "^GH_AW_ASSETS_MAX_SIZE_KB$", "^GH_AW_SAFE_OUTPUTS$", "^GITHUB_REPOSITORY$", "^GITHUB_SERVER_URL$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_CODEX_SHELL_POLICY_82f6585bd0d42c57_EOF
+          GH_AW_CODEX_SHELL_POLICY_44e78737e3f8461e_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }
@@ -1001,7 +981,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
     concurrency:
       group: "gh-aw-conclusion-slack-reaction-intake"
       cancel-in-progress: false
@@ -1288,18 +1267,18 @@ jobs:
           DOCKER_SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK_PATH" 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.22'
           
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_5f49044e5cdadb99_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_80dadef5d2f02b2f_EOF
           [history]
           persistence = "none"
           
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_MCP_CONFIG_5f49044e5cdadb99_EOF
+          GH_AW_MCP_CONFIG_80dadef5d2f02b2f_EOF
           
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_4c112857ade8706d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_d621fe089ad25847_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
             },
@@ -1310,11 +1289,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_4c112857ade8706d_EOF
+          GH_AW_MCP_CONFIG_d621fe089ad25847_EOF
           
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_88061b1c80ce78bb_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_45a344e9b7e61fd6_EOF
           model_provider = "openai-proxy"
           [model_providers.openai-proxy]
           name = "OpenAI AWF proxy"
@@ -1324,7 +1303,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_CODEX_SHELL_POLICY_88061b1c80ce78bb_EOF
+          GH_AW_CODEX_SHELL_POLICY_45a344e9b7e61fd6_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }
@@ -1465,7 +1444,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
     timeout-minutes: 15
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/slack-reaction-intake"
@@ -1533,7 +1511,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,172.30.0.1,api.openai.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,chatgpt.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openai.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,ppa.launchpad.net,raw.githubusercontent.com,s.symcb.com,s.symcd.com,security.ubuntu.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"allowed\":[\"triage-needed\",\"from-slack\"],\"max\":20},\"create_issue\":{\"max\":10,\"title_prefix\":\"[Slack Intake] \"},\"create_report_incomplete_issue\":{},\"mentions\":{\"enabled\":false},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"from-slack\",\"triage-needed\"],\"max\":10,\"title_prefix\":\"[Slack Intake] \"},\"create_report_incomplete_issue\":{},\"mentions\":{\"enabled\":false},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/slack-reaction-intake.md
+++ b/.github/workflows/slack-reaction-intake.md
@@ -39,12 +39,10 @@ safe-outputs:
   allowed-github-references: []
   create-issue:
     title-prefix: "[Slack Intake] "
-    max: 10
-  add-labels:
-    allowed:
-      - triage-needed
+    labels:
       - from-slack
-    max: 20
+      - triage-needed
+    max: 10
   noop:
 ---
 
@@ -77,23 +75,21 @@ workflows. Do not create issues for them in this workflow.
 
 ## Process
 
-### Step 1: Identify Slack Fixture Files
+### Step 1: Extract Intake Candidates
 
-Determine which fixture files triggered this run.
-
-If triggered by push:
+Run the deterministic extractor and use its JSON as the source of truth:
 
 ```bash
-git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -E '^slack-fixtures/.*\.json$' || echo "No Slack fixture files in diff"
+node .github/scripts/slack-reaction-intake-candidates.mjs
 ```
 
-If triggered by `workflow_dispatch`, process all fixture files:
+Do not manually rediscover fixture files, parse raw fixture JSON, or call the
+Slack API. The extractor returns:
 
-```bash
-find slack-fixtures -name '*.json' 2>/dev/null
-```
+- `fixture_files`
+- `candidates`
 
-If no fixture files exist, call `noop` with:
+If `fixture_files` is empty, call `noop` with:
 
 ```text
 Skipped - no Slack fixture files found.
@@ -101,63 +97,23 @@ Skipped - no Slack fixture files found.
 
 Then stop.
 
-### Step 2: Read Fixtures
+If `candidates` is empty, call `noop` with:
 
-For each fixture file, read the JSON:
-
-```bash
-cat <fixture-file>
+```text
+No Slack inbox_tray reaction intake candidates found, or all candidates already had issues.
 ```
 
-Fixtures may contain:
+Then stop.
 
-- top-level `messages`
-- top-level `events`
-- channel or thread groupings with message-like objects
-
-Extract Slack messages with these fields when present:
-
-- `channel_id`
-- `channel_name`
-- `thread_ts`
-- `message_ts`
-- `permalink`
-- `author_name`
-- `created_at`
-- `text`
-- `reactions`
-
-Extract reaction events with these fields when present:
-
-- `event_id`
-- `type`
-- `reaction`
-- `user_id`
-- `channel_id`
-- `message_ts`
-- `thread_ts`
-- `permalink`
-- `received_at`
-
-### Step 3: Match Reaction Events to Messages
-
-Find messages that should create intake issues:
-
-- A message has `reactions` containing `inbox_tray`; or
-- A top-level `reaction_added` event has `reaction: "inbox_tray"` and can be
-  matched to a message by `channel_id` plus `message_ts`.
-
-When a matching event has no corresponding message text, skip it unless the
-event itself contains enough text to create a useful issue. Do not create empty
-or vague issues.
-
-### Step 4: Idempotency
+### Step 2: Idempotency
 
 Before creating an issue, compute an idempotency key:
 
 ```text
 slack-reaction-intake:<channel_id>:<message_ts>:inbox_tray
 ```
+
+Use the `idempotency_key` returned by the extractor.
 
 Check for existing open or closed issues that already contain this key:
 
@@ -172,42 +128,39 @@ If any issue already exists for the key, skip creating a duplicate.
 Also skip if an existing issue body contains the same Slack permalink and was
 created by Slack Reaction Intake.
 
-### Step 5: Create Intake Issues
+### Step 3: Create Intake Issues
 
 For each unique intake candidate, create one GitHub issue.
 
-The title should be short and actionable:
+Use the extractor-provided `title` as the issue title. The safe output handler
+will add the `[Slack Intake] ` prefix.
 
-```text
-<concise request summary from Slack>
-```
-
-The body should use this format:
+Use this body format:
 
 ```markdown
 ## Slack Intake
 
 ### Request
 
-<one-paragraph summary of the Slack request>
+<candidate.summary>
 
 ### Source
 
-- Channel: `#channel-name`
+- Channel: `<candidate.channel_name>`
 - Reaction: `:inbox_tray:`
-- Slack source: <permalink or "fixture permalink unavailable">
-- Fixture: `slack-fixtures/<filename>.json`
+- Slack source: <candidate.permalink or "fixture permalink unavailable">
+- Fixture: `<candidate.fixture>`
 
 ### Copied Slack Context
 
-> <short copied message excerpt>
+> <candidate.author_name>: <candidate.copied_context>
 
 ### Triage Notes
 
 - Created from a Slack reaction signal.
 - Needs product triage before commitment.
 
-<!-- slack-reaction-intake:<channel_id>:<message_ts>:inbox_tray -->
+<!-- <candidate.idempotency_key> -->
 ```
 
 For source links, use the raw `permalink` from the fixture only when it starts
@@ -219,12 +172,15 @@ human-readable display name. If it is missing, `unknown`, or looks like a Slack
 ID such as `U123...`, `W123...`, or `B123...`, omit the author label or use
 `Slack participant`. Do not expose raw Slack user IDs in GitHub issues.
 
-After creating the issue, add both labels:
+The safe-output handler automatically adds both labels:
 
 - `from-slack`
 - `triage-needed`
 
-### Step 6: No Intake
+After all create-issue safe-output calls have been made, stop. Do not keep
+analyzing the repository.
+
+### Step 4: No Intake
 
 If fixture files were processed but no new `inbox_tray` intake issues were
 created, call `noop` with:


### PR DESCRIPTION
## Summary
- add a deterministic Slack reaction candidate extractor for fixture files
- simplify Slack Reaction Intake to consume extractor output instead of manually parsing fixtures
- attach Slack intake labels through the create-issue safe output policy

## Verification
- node .github/scripts/slack-reaction-intake-candidates.mjs
- gh aw compile slack-reaction-intake --approve
- gh aw validate slack-reaction-intake