### PR TITLE
Resolve Slack handles and dispatch intake triage

### DIFF
--- a/.github/workflows/intake-triage.lock.yml
+++ b/.github/workflows/intake-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"9503e5743897b056c60d9986f42a155f0c28104ef531b353f505f16c8cefe429","body_hash":"99a61120e4ab9be99add03f60c382a831297597c84824eb8eba637f64c061fff","compiler_version":"v0.77.4","strict":true,"agent_id":"codex","agent_model":"gpt-5-codex"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"0141e522063c3ad3e550b3cb14312303ebc7c4c3c71744f86e8a33d278b305b1","body_hash":"717232801396eb1b0214f2a648ac537e3c3fe3bf7465be0a37e1f91c7cd05fd2","compiler_version":"v0.77.4","strict":true,"agent_id":"codex","agent_model":"gpt-5-codex"}
 # gh-aw-manifest: {"version":1,"secrets":["AW_TOKEN","CODEX_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","OPENAI_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"4c7307f890279fa5971acae8899475901fea9447","version":"v0.77.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -60,12 +60,22 @@ on:
     types:
     - labeled
   # roles: all # Roles processed as role check in pre-activation job
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        default: ""
+        description: "Agent caller context (used internally by Agentic Workflows)."
+        required: false
+        type: string
+      issue_number:
+        description: Issue number to triage when invoked by another workflow.
+        required: true
 
 permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: intake-triage-${{ github.event.issue.number }}
+  group: intake-triage-${{ github.event.issue.number || inputs.issue_number || github.run_id }}
 
 run-name: "Intake Request Triage"
 
@@ -196,31 +206,32 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ runner.temp }}/gh-aw/safeoutputs/outputs.jsonl
           GH_AW_EXPR_1A3A194A: ${{ github.event.discussion.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'discussion' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_463A214A: ${{ github.event.pull_request.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'pull_request' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
+          GH_AW_EXPR_54492A5B: ${{ github.event.issue.number || inputs.issue_number }}
           GH_AW_EXPR_802A9F6A: ${{ github.event.issue.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'issue' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_FF1D34CE: ${{ github.event.comment.id || fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').comment_id }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
-          GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_INPUTS_ISSUE_NUMBER: ${{ inputs.issue_number }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_dc251c037228c6cd_EOF'
+          cat << 'GH_AW_PROMPT_4f175a46e227fefa_EOF'
           <system>
-          GH_AW_PROMPT_dc251c037228c6cd_EOF
+          GH_AW_PROMPT_4f175a46e227fefa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dc251c037228c6cd_EOF'
+          cat << 'GH_AW_PROMPT_4f175a46e227fefa_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), add_labels(max:5), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_dc251c037228c6cd_EOF
+          GH_AW_PROMPT_4f175a46e227fefa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_dc251c037228c6cd_EOF'
+          cat << 'GH_AW_PROMPT_4f175a46e227fefa_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -249,20 +260,21 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_dc251c037228c6cd_EOF
+          GH_AW_PROMPT_4f175a46e227fefa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dc251c037228c6cd_EOF'
+          cat << 'GH_AW_PROMPT_4f175a46e227fefa_EOF'
           </system>
           {{#runtime-import .github/workflows/intake-triage.md}}
-          GH_AW_PROMPT_dc251c037228c6cd_EOF
+          GH_AW_PROMPT_4f175a46e227fefa_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_ENGINE_ID: "codex"
-          GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_AW_EXPR_54492A5B: ${{ github.event.issue.number || inputs.issue_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_AW_INPUTS_ISSUE_NUMBER: ${{ inputs.issue_number }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -275,13 +287,14 @@ jobs:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_EXPR_1A3A194A: ${{ github.event.discussion.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'discussion' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_463A214A: ${{ github.event.pull_request.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'pull_request' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
+          GH_AW_EXPR_54492A5B: ${{ github.event.issue.number || inputs.issue_number }}
           GH_AW_EXPR_802A9F6A: ${{ github.event.issue.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'issue' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_FF1D34CE: ${{ github.event.comment.id || fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').comment_id }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
-          GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_INPUTS_ISSUE_NUMBER: ${{ inputs.issue_number }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
         with:
           script: |
@@ -296,13 +309,14 @@ jobs:
               substitutions: {
                 GH_AW_EXPR_1A3A194A: process.env.GH_AW_EXPR_1A3A194A,
                 GH_AW_EXPR_463A214A: process.env.GH_AW_EXPR_463A214A,
+                GH_AW_EXPR_54492A5B: process.env.GH_AW_EXPR_54492A5B,
                 GH_AW_EXPR_802A9F6A: process.env.GH_AW_EXPR_802A9F6A,
                 GH_AW_EXPR_FF1D34CE: process.env.GH_AW_EXPR_FF1D34CE,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
-                GH_AW_GITHUB_EVENT_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_ISSUE_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_INPUTS_ISSUE_NUMBER: process.env.GH_AW_INPUTS_ISSUE_NUMBER,
                 GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
@@ -465,9 +479,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_4521fdedca6d368a_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_314b826eed5e10a9_EOF
           {"add_comment":{"max":2},"add_labels":{"allowed":["triaged","needs-more-info","duplicate","rice:high","rice:medium","rice:low","kano:must-be","kano:one-dimensional","kano:attractive","kano:indifferent","aligns-with-current"],"max":5},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${AW_TOKEN}","max":1,"project":"https://github.com/users/chrizbo/projects/2"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4521fdedca6d368a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_314b826eed5e10a9_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -721,7 +735,7 @@ jobs:
           DOCKER_SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK_PATH" 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.22'
           
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_8c2dfc385722a9f9_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_04aeca41ad42f309_EOF
           [history]
           persistence = "none"
           
@@ -740,11 +754,11 @@ jobs:
           
           [mcp_servers.safeoutputs."guard-policies".write-sink]
           accept = ["*"]
-          GH_AW_MCP_CONFIG_8c2dfc385722a9f9_EOF
+          GH_AW_MCP_CONFIG_04aeca41ad42f309_EOF
           
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8c2dfc385722a9f9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_04aeca41ad42f309_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -769,11 +783,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8c2dfc385722a9f9_EOF
+          GH_AW_MCP_CONFIG_04aeca41ad42f309_EOF
           
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_265719604906a776_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_bae39c702216acdc_EOF
 
           model_provider = "openai-proxy"
 
@@ -785,7 +799,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^GH_AW_ASSETS_ALLOWED_EXTS$", "^GH_AW_ASSETS_BRANCH$", "^GH_AW_ASSETS_MAX_SIZE_KB$", "^GH_AW_SAFE_OUTPUTS$", "^GITHUB_REPOSITORY$", "^GITHUB_SERVER_URL$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_CODEX_SHELL_POLICY_265719604906a776_EOF
+          GH_AW_CODEX_SHELL_POLICY_bae39c702216acdc_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }
@@ -1331,18 +1345,18 @@ jobs:
           DOCKER_SOCK_GID=$(stat -c '%g' "$DOCKER_SOCK_PATH" 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.22'
           
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_5ddb40adf1ab5973_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_a7ef39f7eb46b5f9_EOF
           [history]
           persistence = "none"
           
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_MCP_CONFIG_5ddb40adf1ab5973_EOF
+          GH_AW_MCP_CONFIG_a7ef39f7eb46b5f9_EOF
           
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_fb460893b5574afd_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ef0133e79f68ac5d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
             },
@@ -1353,11 +1367,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_fb460893b5574afd_EOF
+          GH_AW_MCP_CONFIG_ef0133e79f68ac5d_EOF
           
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_1dfd80e67ea008bc_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_7187ecc57c93734f_EOF
           model_provider = "openai-proxy"
           [model_providers.openai-proxy]
           name = "OpenAI AWF proxy"
@@ -1367,7 +1381,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["^CODEX_API_KEY$", "^HOME$", "^OPENAI_API_KEY$", "^PATH$"]
-          GH_AW_CODEX_SHELL_POLICY_1dfd80e67ea008bc_EOF
+          GH_AW_CODEX_SHELL_POLICY_7187ecc57c93734f_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }

--- a/.github/workflows/intake-triage.md
+++ b/.github/workflows/intake-triage.md
@@ -14,10 +14,15 @@ on:
   issues:
     types: [labeled]
     names: [triage-needed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to triage when invoked by another workflow."
+        required: true
   roles: all
 
 concurrency:
-  group: intake-triage-${{ github.event.issue.number }}
+  group: intake-triage-${{ github.event.issue.number || inputs.issue_number || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -72,13 +77,19 @@ Your job is to evaluate incoming intake requests (labeled `triage-needed`)
 against the team's strategy, score them, check for completeness, detect
 duplicates, and assess alignment with current work.
 
+Target issue number:
+
+```text
+${{ github.event.issue.number || inputs.issue_number }}
+```
+
 ## Activation Guard
 
 Only proceed if the issue has the `triage-needed` label. Check by reading
 the issue's current labels:
 
 ```bash
-gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} \
+gh issue view ${{ github.event.issue.number || inputs.issue_number }} --repo ${{ github.repository }} \
   --json labels --jq '[.labels[].name]'
 ```
 
@@ -88,7 +99,7 @@ with "Skipped — issue does not have triage-needed label" and stop.
 Also check whether the issue has already been triaged:
 
 ```bash
-gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} \
+gh issue view ${{ github.event.issue.number || inputs.issue_number }} --repo ${{ github.repository }} \
   --json labels --jq '.labels[].name' | grep -q '^triaged$' && echo "ALREADY_TRIAGED=true" || echo "ALREADY_TRIAGED=false"
 ```
 
@@ -99,7 +110,7 @@ If already triaged, call `noop` with "Issue already triaged" and stop.
 ### 1a: Read the intake request
 
 ```bash
-gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} \
+gh issue view ${{ github.event.issue.number || inputs.issue_number }} --repo ${{ github.repository }} \
   --json number,title,body,labels,author,createdAt \
   --jq '{number, title, body, labels: [.labels[].name], author: .author.login, createdAt}'
 ```

--- a/.github/workflows/slack-fixture-fetcher.yml
+++ b/.github/workflows/slack-fixture-fetcher.yml
@@ -86,6 +86,35 @@ jobs:
               return json;
             }
 
+            const users = new Map();
+
+            async function slackUserHandle(userId) {
+              if (!userId || !/^U[A-Z0-9]+$/.test(userId)) {
+                return "";
+              }
+              if (users.has(userId)) {
+                return users.get(userId);
+              }
+
+              try {
+                const user = await slack("users.info", { user: userId });
+                const profile = user.user?.profile || {};
+                const handle =
+                  user.user?.name ||
+                  profile.display_name_normalized ||
+                  profile.display_name ||
+                  profile.real_name_normalized ||
+                  profile.real_name ||
+                  "";
+                users.set(userId, handle);
+                return handle;
+              } catch (error) {
+                console.warn(`Could not resolve Slack user ${userId}: ${error.message}`);
+                users.set(userId, "");
+                return "";
+              }
+            }
+
             function isoFromTs(ts) {
               const [seconds, micros = "0"] = String(ts).split(".");
               const millis = Number(seconds) * 1000 + Math.floor(Number(micros.padEnd(6, "0")) / 1000);
@@ -96,7 +125,11 @@ jobs:
               return `https://slack.com/archives/${channelId}/p${String(ts).replace(".", "")}`;
             }
 
-            function authorNameFor(message) {
+            async function authorNameFor(message) {
+              const handle = await slackUserHandle(message.user);
+              if (handle) {
+                return `@${handle.replace(/^@/, "")}`;
+              }
               if (message.username && !/^[UW][A-Z0-9]+$/.test(message.username)) {
                 return message.username;
               }
@@ -141,7 +174,7 @@ jobs:
                     message_ts: message.ts,
                     permalink: permalinkFor(channelId, message.ts),
                     author_id: message.user || message.bot_id || "unknown",
-                    author_name: authorNameFor(message),
+                    author_name: await authorNameFor(message),
                     created_at: isoFromTs(message.ts),
                     text: message.text,
                     reactions: (message.reactions || []).map((reaction) => reaction.name),

--- a/.github/workflows/slack-intake-triage-dispatch.yml
+++ b/.github/workflows/slack-intake-triage-dispatch.yml
@@ -1,0 +1,51 @@
+name: Slack Intake Triage Dispatch
+
+on:
+  workflow_run:
+    workflows: ["Slack Reaction Intake"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  issues: read
+  contents: read
+
+concurrency:
+  group: slack-intake-triage-dispatch
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Dispatch intake triage for Slack issues
+        run: |
+          set -euo pipefail
+
+          mapfile -t issue_numbers < <(
+            gh issue list \
+              --repo "$GH_REPO" \
+              --state open \
+              --label from-slack \
+              --label triage-needed \
+              --limit 20 \
+              --json number,labels \
+              --jq '.[] | select((.labels | map(.name) | index("triaged")) | not) | .number'
+          )
+
+          if [ "${#issue_numbers[@]}" -eq 0 ]; then
+            echo "No untriaged Slack intake issues found."
+            exit 0
+          fi
+
+          for issue_number in "${issue_numbers[@]}"; do
+            echo "Dispatching Intake Request Triage for issue #${issue_number}"
+            gh workflow run "Intake Request Triage" \
+              --repo "$GH_REPO" \
+              --field "issue_number=${issue_number}"
+          done

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -156,8 +156,9 @@ gh variable set SLACK_ALLOWED_CHANNEL_IDS --body "C0123456789,C9876543210"
 
 If enabling the Slack Fixture Fetcher workflow, also set `SLACK_BOT_TOKEN` as a
 repository secret. The first read-only demo requires `channels:history` and
-`reactions:read` on the Slack app, plus `groups:history` if the allowlisted
-channel is private.
+`reactions:read` on the Slack app. Add `users:read` to resolve Slack user IDs
+to `@handle` labels in copied context. Also add `groups:history` if the
+allowlisted channel is private.
 
 ### 4. Create an Intake Triage project
 

--- a/docs/slack-integration-plan.md
+++ b/docs/slack-integration-plan.md
@@ -338,6 +338,7 @@ type.
 Required for public channel context:
 
 - `channels:history` - read messages in public channels the app can access.
+- `users:read` - resolve message authors to Slack handles for copied context.
 
 Required for private channel context:
 
@@ -364,6 +365,7 @@ Often paired with:
   a public channel.
 - `groups:history` - fetch the original message in a private channel where the
   app is a member.
+- `users:read` - resolve the reacted message author to a readable `@handle`.
 
 Recommended MVP: `reactions:read` plus the matching history scope for each
 allowed channel type.


### PR DESCRIPTION
## Summary
- resolve Slack message authors via users.info so fixtures can store readable @handles
- add a Slack Intake Triage Dispatch workflow to explicitly start Intake Request Triage for Slack-created issues
- add workflow_dispatch support to Intake Request Triage for bridge-dispatched issue numbers
- document the users:read Slack scope for handle resolution

## Verification
- gh aw compile intake-triage --approve
- gh aw validate intake-triage
- ruby -e 'require "yaml"; %w[.github/workflows/slack-fixture-fetcher.yml .github/workflows/slack-intake-triage-dispatch.yml].each { |f| YAML.load_file(f); puts "yaml ok #{f}" }'
- node .github/scripts/slack-reaction-intake-candidates.mjs