### PR TITLE
Make Slack postbacks idempotent

### DIFF
--- a/.github/workflows/slack-postback-dispatch.yml
+++ b/.github/workflows/slack-postback-dispatch.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   contents: read
-  issues: read
+  issues: write
 
 concurrency:
   group: slack-postback-${{ github.event.workflow_run.id || inputs.run_id || github.run_id }}
@@ -56,6 +56,24 @@ jobs:
 
             function gh(args) {
               return execFileSync("gh", args, { encoding: "utf8" });
+            }
+
+            function ensurePostbackLabel() {
+              try {
+                gh([
+                  "label",
+                  "create",
+                  "slack-postback-sent",
+                  "--repo",
+                  repo,
+                  "--color",
+                  "6f42c1",
+                  "--description",
+                  "Slack acknowledgement has been posted for this issue"
+                ]);
+              } catch {
+                // Label already exists or cannot be created; issue edit below will surface real failures.
+              }
             }
 
             function parseThreadTs(body) {
@@ -101,6 +119,9 @@ jobs:
               if (!labels.has("from-slack")) {
                 return false;
               }
+              if (labels.has("slack-postback-sent")) {
+                return false;
+              }
               if (!issue.body || !issue.body.includes("slack-reaction-intake:")) {
                 return false;
               }
@@ -144,6 +165,17 @@ jobs:
               if (!response.ok || !result.ok) {
                 throw new Error(`Slack post failed for #${issue.number}: ${result.error || response.statusText}`);
               }
+
+              ensurePostbackLabel();
+              gh([
+                "issue",
+                "edit",
+                String(issue.number),
+                "--repo",
+                repo,
+                "--add-label",
+                "slack-postback-sent"
+              ]);
 
               console.log(`Posted Slack acknowledgement for #${issue.number} to ${source.channel} at ${result.ts}.`);
             }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -239,6 +239,8 @@ The following labels are used by workflows. Create them in your repository:
 **External-source labels:**
 - `from-slack` — marks issues or comments created from Slack context or Slack
   reaction intake
+- `slack-postback-sent` — marks Slack-originated issues that already received a
+  Slack thread acknowledgement
 
 ### 6. Create issues using templates
 

--- a/docs/slack-integration-plan.md
+++ b/docs/slack-integration-plan.md
@@ -538,6 +538,8 @@ Suggested secrets:
 - Create intake issues with Slack permalink evidence and the `from-slack`
   label.
 - Add idempotency so the same message cannot create repeated issues.
+- Mark issues with `slack-postback-sent` after a successful Slack
+  acknowledgement so reruns do not post duplicate replies.
 
 ### Phase 3: Commitment Reconciliation
 


### PR DESCRIPTION
## Summary
- skip Slack post-back issues already marked with slack-postback-sent
- add the marker label only after Slack accepts the acknowledgement
- document the marker label in setup and Slack integration notes

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/slack-postback-dispatch.yml"); puts "yaml ok"'
- node -e 'const issue={labels:[{name:"from-slack"},{name:"slack-postback-sent"}],body:"slack-reaction-intake:C0B7ER3RZ53:1780345438.463139:inbox_tray"}; const labels=new Set(issue.labels.map(l=>l.name)); console.log(!labels.has("slack-postback-sent"))'