### PR TITLE
Add Slack author fallback map

### DIFF
--- a/.github/workflows/slack-fixture-fetcher.yml
+++ b/.github/workflows/slack-fixture-fetcher.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_ALLOWED_CHANNEL_IDS: ${{ vars.SLACK_ALLOWED_CHANNEL_IDS }}
+      SLACK_USER_ID_MAP: ${{ vars.SLACK_USER_ID_MAP }}
       INPUT_CHANNEL_IDS: ${{ inputs.channel_ids }}
       LOOKBACK_HOURS: ${{ inputs.lookback_hours }}
     steps:
@@ -51,6 +52,7 @@ jobs:
             const allowed = new Set(configuredAllowed);
             const channelIds = requested.length ? requested : configuredAllowed;
             const lookbackHours = Number(process.env.LOOKBACK_HOURS || "24");
+            const userIdMap = parseUserIdMap(process.env.SLACK_USER_ID_MAP || "");
 
             if (!token) {
               throw new Error("SLACK_BOT_TOKEN is not configured.");
@@ -86,9 +88,41 @@ jobs:
               return json;
             }
 
+            function parseUserIdMap(value) {
+              if (!value.trim()) {
+                return {};
+              }
+              try {
+                const parsed = JSON.parse(value);
+                if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+                  throw new Error("expected a JSON object");
+                }
+                return parsed;
+              } catch (error) {
+                throw new Error(`SLACK_USER_ID_MAP must be a JSON object: ${error.message}`);
+              }
+            }
+
+            function normalizeHandle(value) {
+              if (!value || typeof value !== "string") {
+                return "";
+              }
+              return value.trim().replace(/^@/, "");
+            }
+
+            function handleFromProfile(profile) {
+              return normalizeHandle(
+                profile?.display_name_normalized ||
+                profile?.display_name ||
+                profile?.real_name_normalized ||
+                profile?.real_name ||
+                ""
+              );
+            }
+
             const users = new Map();
 
-            async function slackUserHandle(userId) {
+            async function slackUserHandle(userId, message) {
               if (!userId || !/^U[A-Z0-9]+$/.test(userId)) {
                 return "";
               }
@@ -96,16 +130,24 @@ jobs:
                 return users.get(userId);
               }
 
+              const configuredHandle = normalizeHandle(userIdMap[userId]);
+              if (configuredHandle) {
+                users.set(userId, configuredHandle);
+                return configuredHandle;
+              }
+
+              const messageProfileHandle = handleFromProfile(message?.user_profile);
+              if (messageProfileHandle) {
+                users.set(userId, messageProfileHandle);
+                return messageProfileHandle;
+              }
+
               try {
                 const user = await slack("users.info", { user: userId });
                 const profile = user.user?.profile || {};
                 const handle =
-                  user.user?.name ||
-                  profile.display_name_normalized ||
-                  profile.display_name ||
-                  profile.real_name_normalized ||
-                  profile.real_name ||
-                  "";
+                  normalizeHandle(user.user?.name) ||
+                  handleFromProfile(profile);
                 users.set(userId, handle);
                 return handle;
               } catch (error) {
@@ -126,7 +168,7 @@ jobs:
             }
 
             async function authorNameFor(message) {
-              const handle = await slackUserHandle(message.user);
+              const handle = await slackUserHandle(message.user, message);
               if (handle) {
                 return `@${handle.replace(/^@/, "")}`;
               }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -166,6 +166,13 @@ repository secret. The first read-only demo requires `channels:history` and
 to `@handle` labels in copied context. Also add `groups:history` if the
 allowlisted channel is private.
 
+If Slack can read messages but cannot resolve a demo workspace user through
+`users.info`, set an optional JSON fallback map:
+
+```bash
+gh variable set SLACK_USER_ID_MAP --body '{"U0123456789":"@handle"}'
+```
+
 If enabling Slack post-backs, add `chat:write` to the Slack app and invite the
 app to every allowlisted channel where it should reply.
 


### PR DESCRIPTION
## Summary
- Add optional `SLACK_USER_ID_MAP` repo variable support to Slack Fixture Fetcher
- Prefer configured fallback handles and embedded Slack message profile data before `users.info`
- Document the fallback map for demo workspaces where Slack history can read messages but `users.info` returns `user_not_found`

## Verification
- `git diff --check`
- Local Node sanity check for mapping `U0B7G54TZ54` to `@chrisbutler`

## Follow-up
- Set `SLACK_USER_ID_MAP` for the demo workspace user and rerun Slack Fixture Fetcher so PR #231 updates with a readable author.