### PR TITLE
Fallback to scanning Slack fixtures

### DIFF
--- a/.github/scripts/slack-reaction-intake-candidates.mjs
+++ b/.github/scripts/slack-reaction-intake-candidates.mjs
@@ -2,21 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-function listFixtureFiles() {
-  if (process.env.GITHUB_EVENT_NAME === "push") {
-    try {
-      const output = execFileSync("git", ["diff", "--name-only", "HEAD~1", "HEAD"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-      return output
-        .split(/\r?\n/)
-        .filter((file) => /^slack-fixtures\/.*\.json$/.test(file));
-    } catch {
-      return [];
-    }
-  }
-
+function listAllFixtureFiles() {
   const root = "slack-fixtures";
   if (!fs.existsSync(root)) {
     return [];
@@ -35,6 +21,31 @@ function listFixtureFiles() {
   };
   walk(root);
   return files.sort();
+}
+
+function listFixtureFilesFromPushDiff() {
+  try {
+    const output = execFileSync("git", ["diff", "--name-only", "HEAD~1", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return output
+      .split(/\r?\n/)
+      .filter((file) => /^slack-fixtures\/.*\.json$/.test(file));
+  } catch {
+    return [];
+  }
+}
+
+function listFixtureFiles() {
+  if (process.env.GITHUB_EVENT_NAME === "push") {
+    const changedFiles = listFixtureFilesFromPushDiff();
+    if (changedFiles.length) {
+      return changedFiles;
+    }
+  }
+
+  return listAllFixtureFiles();
 }
 
 function textFrom(value) {


### PR DESCRIPTION
## Summary
- Make Slack Reaction Intake candidate extraction fall back to scanning `slack-fixtures/` when push diff discovery finds no fixture files
- Preserve changed-file discovery when it works, so ordinary fixture pushes still stay scoped

## Why
After merging the latest Slack fixture PR, Slack Reaction Intake completed successfully but emitted noop: `Skipped - no Slack fixture files found.` The fixture existed in the repo, so the extractor needs a durable fallback for merge/shallow-diff edge cases.

## Verification
- `GITHUB_EVENT_NAME=push node .github/scripts/slack-reaction-intake-candidates.mjs`
- `git diff --check`